### PR TITLE
Fix for  Issue 50: Patch: handle partial responses correctly

### DIFF
--- a/xmpp/xmpp.class.php
+++ b/xmpp/xmpp.class.php
@@ -437,64 +437,67 @@
             if($payload != '' && $this->mode == 'cgi') $this->log("[[XMPPGet]] \n".$payload, 4);
             $payload = $this->executePlugin('jaxl_pre_handler', $payload);
            
-            $xmls = JAXLUtil::splitXML($payload);
-            $pktCnt = count($xmls);
-            $this->totalRcvdPkt += $pktCnt;
-            $buffer = array();
-            
-            foreach($xmls as $pktNo => $xml) {
-                if($pktNo == $pktCnt-1) {
-                    if(substr($xml, -1, 1) != '>') {
-                        $this->buffer .= $xml;
-                        break;
+            if ($xmls = JAXLUtil::splitXML($payload)) {
+                $pktCnt = count($xmls);
+                $this->totalRcvdPkt += $pktCnt;
+                $buffer = array();
+                
+                foreach($xmls as $pktNo => $xml) {
+                    if($pktNo == $pktCnt-1) {
+                        if(substr($xml, -1, 1) != '>') {
+                            $this->buffer .= $xml;
+                            break;
+                        }
+                    }
+                    
+                    if(substr($xml, 0, 7) == '<stream') $arr = $this->xml->xmlize($xml);
+                    else $arr = JAXLXml::parse($xml, $this->getSXE);
+                    if($arr === false) { $this->buffer .= $xml; continue; }
+
+                    switch(true) {
+                        case isset($arr['stream:stream']):
+                            XMPPGet::streamStream($arr['stream:stream'], $this);
+                            break;
+                        case isset($arr['stream:features']):
+                            XMPPGet::streamFeatures($arr['stream:features'], $this);
+                            break;
+                        case isset($arr['stream:error']):
+                            XMPPGet::streamError($arr['stream:error'], $this);
+                            break;
+                        case isset($arr['failure']);
+                            XMPPGet::failure($arr['failure'], $this);
+                            break;
+                        case isset($arr['proceed']):
+                            XMPPGet::proceed($arr['proceed'], $this);
+                            break;
+                        case isset($arr['challenge']):
+                            XMPPGet::challenge($arr['challenge'], $this);
+                            break;
+                        case isset($arr['success']):
+                            XMPPGet::success($arr['success'], $this);
+                            break;
+                        case isset($arr['presence']):
+                            $buffer['presence'][] = $arr['presence'];
+                            break;
+                        case isset($arr['message']):
+                            $buffer['message'][] = $arr['message'];
+                            break;
+                        case isset($arr['iq']):
+                            XMPPGet::iq($arr['iq'], $this);
+                            break;
+                        default:
+                            $jaxl->log("[[XMPPGet]] \nUnrecognized payload received from jabber server...");
+                            throw new JAXLException("[[XMPPGet]] Unrecognized payload received from jabber server...");
+                            break;
                     }
                 }
                 
-                if(substr($xml, 0, 7) == '<stream') $arr = $this->xml->xmlize($xml);
-                else $arr = JAXLXml::parse($xml, $this->getSXE);
-                if($arr === false) { $this->buffer .= $xml; continue; }
-
-                switch(true) {
-                    case isset($arr['stream:stream']):
-                        XMPPGet::streamStream($arr['stream:stream'], $this);
-                        break;
-                    case isset($arr['stream:features']):
-                        XMPPGet::streamFeatures($arr['stream:features'], $this);
-                        break;
-                    case isset($arr['stream:error']):
-                        XMPPGet::streamError($arr['stream:error'], $this);
-                        break;
-                    case isset($arr['failure']);
-                        XMPPGet::failure($arr['failure'], $this);
-                        break;
-                    case isset($arr['proceed']):
-                        XMPPGet::proceed($arr['proceed'], $this);
-                        break;
-                    case isset($arr['challenge']):
-                        XMPPGet::challenge($arr['challenge'], $this);
-                        break;
-                    case isset($arr['success']):
-                        XMPPGet::success($arr['success'], $this);
-                        break;
-                    case isset($arr['presence']):
-                        $buffer['presence'][] = $arr['presence'];
-                        break;
-                    case isset($arr['message']):
-                        $buffer['message'][] = $arr['message'];
-                        break;
-                    case isset($arr['iq']):
-                        XMPPGet::iq($arr['iq'], $this);
-                        break;
-                    default:
-                        $jaxl->log("[[XMPPGet]] \nUnrecognized payload received from jabber server...");
-                        throw new JAXLException("[[XMPPGet]] Unrecognized payload received from jabber server...");
-                        break;
-                }
+                if(isset($buffer['presence'])) XMPPGet::presence($buffer['presence'], $this);
+                if(isset($buffer['message'])) XMPPGet::message($buffer['message'], $this);
+                unset($buffer); 
+            } else {
+                    $this->buffer .= $payload;
             }
-            
-            if(isset($buffer['presence'])) XMPPGet::presence($buffer['presence'], $this);
-            if(isset($buffer['message'])) XMPPGet::message($buffer['message'], $this);
-            unset($buffer); 
 
             $this->executePlugin('jaxl_post_handler', $payload);
             return $payload;


### PR DESCRIPTION
http://code.google.com/p/jaxl/issues/detail?id=50

While talking to Openfire SVN r12903 there was a following exchange
(using TLS and SASL PLAIN):

C: <auth xmlns="urn:ietf:params:xml:ns:xmpp-sasl" mechanism="PLAIN">sOMeBaSE64String=</auth>
S: <
S: success xmlns="urn:ietf:params:xml:ns:xmpp-sasl"/>

Those two packets didn't get combined into a meaningful answer,
hence JAXL was stuck waiting for the result of authentication.
