### PR TITLE
Fixed unwrap funciton in BOSH module (XEP 0206)

### DIFF
--- a/xep/xep_0206.php
+++ b/xep/xep_0206.php
@@ -177,7 +177,7 @@ class XEP_0206 extends XMPPXep {
 	
 	public function unwrap($body) {
 		// a dirty way but it works efficiently
-		if(substr($body -2, 2) == "/>") preg_match_all('/<body (.*?)\/>/smi', $body, $m);
+		if(substr($body, -2, 2) == "/>") preg_match_all('/<body (.*?)\/>/smi', $body, $m);
 		else preg_match_all('/<body (.*?)>(.*)<\/body>/smi', $body, $m);
 		
 		if(isset($m[1][0])) $envelop = "<body ".$m[1][0]."/>";


### PR DESCRIPTION
There was missing comma in the unwrap method of XEP_0206 class.
Therefore, the method did never match the regular expresion and any BOSH
connection was terminated by the server. It works OK now, the idea was
there even before, just incorrectly implemented.

Please, update this bug at Packagist too so people can use the bundled version of JAXL and they don't need to git clone & add manually. Thanks!
