### PR TITLE
The protocol directive from cfg should not be empty

### DIFF
--- a/jaxl.php
+++ b/jaxl.php
@@ -340,8 +340,9 @@ class JAXL extends XMPPStream {
 	
 	public function get_socket_path() {
 		$protocol = ($this->cfg['port'] == 5223 ? "ssl" : "tcp");
-		if ($this->cfg['protocol'])
+		if (!empty($this->cfg['protocol'])) {
 			$protocol = $this->cfg['protocol'];
+		}
 		return $protocol."://".$this->cfg['host'].":".$this->cfg['port'];
 	}
 	


### PR DESCRIPTION
JAXL fails to start due to undefined index protocol:
jaxl_exception:48 - 2015-01-16 09:43:31 - got jaxl exception construct with Undefined index: protocol, 8, /usr/local/path/xmpp-jaxl/JAXL-3.x/jaxl.php, 343