### PR TITLE
Change the visibility of `JAXLLoop::select`

### DIFF
--- a/core/jaxl_loop.php
+++ b/core/jaxl_loop.php
@@ -117,7 +117,7 @@ class JAXLLoop {
 		}
 	}
 	
-	private static function select() {
+	public static function select() {
 		$read = self::$read_fds;
 		$write = self::$write_fds;
 		$except = null;


### PR DESCRIPTION
I am writing a HipChat integration for Phabricator and I need to call `JAXLLoop::select` rather than `JAXLLoop::run`. The reason for this is that the polling mechanism is implemented on the Phabricator end rather than within JAXL itself.