### PR TITLE
Allow log colorization to be disabled

### DIFF
--- a/core/jaxl_logger.php
+++ b/core/jaxl_logger.php
@@ -58,6 +58,7 @@ function _colorize($msg, $verbosity) { error_log(JAXLLogger::colorize($msg, $ver
 
 class JAXLLogger {
 	
+	public static $colorize = true;
 	public static $level = JAXL_DEBUG;
 	public static $path = null;
 	public static $max_log_size = 1000;
@@ -84,6 +85,10 @@ class JAXLLogger {
 	}
 	
 	public static function colorize($msg, $verbosity) {
+		if (self::$colorize) {
+			return $msg;
+		}
+
 		return "\033[".self::$colors[$verbosity]."m".$msg."\033[0m";
 	}
 	

--- a/jaxl.php
+++ b/jaxl.php
@@ -89,6 +89,7 @@ class JAXL extends XMPPStream {
 	
 	// path variables
 	public $log_level = JAXL_INFO;
+	public $log_colorize = true;
 	public $priv_dir;
 	public $tmp_dir;
 	public $log_dir;
@@ -129,6 +130,8 @@ class JAXL extends XMPPStream {
 		//else JAXLLogger::$path = $this->log_dir."/jaxl.log";
 		if(isset($this->cfg['log_level'])) JAXLLogger::$level = $this->log_level = $this->cfg['log_level'];
 		else JAXLLogger::$level = $this->log_level;
+		if(isset($this->cfg['log_colorize'])) JAXLLogger::$colorize = $this->log_colorize = $this->cfg['log_colorize'];
+		else JAXLLogger::$colorize = $this->log_colorize;
 		
 		// env
 		$strict = isset($this->cfg['strict']) ? $this->cfg['strict'] : TRUE;


### PR DESCRIPTION
Currently, it is not possibly to explicitly disable the colorization of log output.