### PR TITLE
Adding JAXLXml->x() for raw XML children

### DIFF
--- a/core/jaxl_xml.php
+++ b/core/jaxl_xml.php
@@ -33,34 +33,35 @@
 * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 * POSSIBILITY OF SUCH DAMAGE.
-* 
+*
 */
 
 /**
- * 
+ *
  * Details: http://abhinavsingh.com/blog/2012/09/jaxlxml-strophe-style-xml-builder-working-with-jaxl-a-networking-library-in-php-part-2/
  * Doc: http://jaxl.readthedocs.org/en/latest/users/xml_objects.html#jaxlxml
- * 
+ *
  * @author abhinavsingh
  *
  */
 class JAXLXml {
-	
+
 	public $name;
 	public $ns = null;
 	public $attrs = array();
+	public $xml = null;
 	public $text = null;
-	
+
 	public $childrens = array();
 	public $parent = null;
 	public $rover = null;
-	
+
 	public function __construct() {
 		$argv = func_get_args();
 		$argc = sizeof($argv);
-		
+
 		$this->name = $argv[0];
-		
+
 		switch($argc) {
 			case 4:
 				$this->ns = $argv[1];
@@ -93,19 +94,19 @@ class JAXLXml {
 			default:
 				break;
 		}
-		
+
 		$this->rover = &$this;
 	}
-	
+
 	public function __destruct() {
-		
+
 	}
-	
+
 	public function attrs($attrs) {
 		$this->rover->attrs = array_merge($this->rover->attrs, $attrs);
 		return $this;
 	}
-	
+
 	public function match_attrs($attrs) {
 		$matches = true;
 		foreach($attrs as $k=>$v) {
@@ -116,19 +117,31 @@ class JAXLXml {
 		}
 		return $matches;
 	}
-	
+
+	public function x($xml, $append=FALSE) {
+		if(!$append) {
+			$this->rover->xml = $xml;
+		}
+		else {
+			if($this->rover->xml === null)
+				$this->rover->xml = '';
+			$this->rover->xml .= $xml;
+		}
+		return $this;
+	}
+
 	public function t($text, $append=FALSE) {
 		if(!$append) {
 			$this->rover->text = $text;
 		}
 		else {
-			if($this->rover->text === null) 
+			if($this->rover->text === null)
 				$this->rover->text = '';
 			$this->rover->text .= $text;
-		} 
+		}
 		return $this;
 	}
-	
+
 	public function c($name, $ns=null, $attrs=array(), $text=null) {
 		$node = new JAXLXml($name, $ns, $attrs, $text);
 		$node->parent = &$this->rover;
@@ -136,19 +149,19 @@ class JAXLXml {
 		$this->rover = &$node;
 		return $this;
 	}
-	
+
 	public function cnode($node) {
 		$node->parent = &$this->rover;
 		$this->rover->childrens[] = &$node;
 		$this->rover = &$node;
 		return $this;
 	}
-	
+
 	public function up() {
 		if($this->rover->parent) $this->rover = &$this->rover->parent;
 		return $this;
 	}
-	
+
 	public function top() {
 		$this->rover = &$this;
 		return $this;
@@ -166,7 +179,7 @@ class JAXLXml {
 		}
 		return false;
 	}
-	
+
 	public function update($name, $ns=null, $attrs=array(), $text=null) {
 		foreach($this->childrens as $k=>$child) {
 			if($child->name == $name) {
@@ -178,22 +191,24 @@ class JAXLXml {
 			}
 		}
 	}
-	
+
 	public function to_string($parent_ns=null) {
 		$xml = '';
-		
+
 		$xml .= '<'.$this->name;
 		if($this->ns && $this->ns != $parent_ns) $xml .= ' xmlns="'.$this->ns.'"';
 		foreach($this->attrs as $k=>$v) if(!is_null($v) && $v !== FALSE) $xml .= ' '.$k.'="'.htmlspecialchars($v).'"';
 		$xml .= '>';
-		
+
 		foreach($this->childrens as $child) $xml .= $child->to_string($this->ns);
-		
-		if($this->text) $xml .= htmlspecialchars($this->text);
+
+		if($this->xml !== null) $xml .= $this->xml;
+
+		if($this->text !== null) $xml .= htmlspecialchars($this->text);
 		$xml .= '</'.$this->name.'>';
 		return $xml;
 	}
-	
+
 }
 
 ?>


### PR DESCRIPTION
This makes things like XEP-0071 possible

For example, this:
```xml
<message>
  <body>test
test 2</body>
  <html xmlns='http://jabber.org/protocol/xhtml-im'>
    <body xmlns='http://www.w3.org/1999/xhtml'>
      <p style='font-weight: bold;'>test</p>
      <br />test 2
    </body>
  </html>
</message>
```

Can be generated like this:
```php
$msg = new XMPPMsg(array(/*...*/), "test\ntest2");
$msg->c('html', null, array('xmlns' => 'http://jabber.org/protocol/xhtml-im'))
  ->c('body', null, array('xmlns' => 'http://www.w3.org/1999/xhtml'))
  ->x("<p style='font-weight: bold;'>test</p><br />test2");
```

Without raw XML, it is impossible to put an unescaped `<br />` tag (or similar) in with normal text content.