### PR TITLE
Check that pcntl_signal exists

### DIFF
--- a/src/JAXL/jaxl.php
+++ b/src/JAXL/jaxl.php
@@ -168,7 +168,7 @@ class JAXL extends XMPPStream
         $jid = ($this->cfg['jid'] !== null) ? new XMPPJid($this->cfg['jid']) : null;
 
         // handle signals
-        if (extension_loaded('pcntl')) {
+        if (extension_loaded('pcntl') && function_exists('pcntl_signal')) {
             pcntl_signal(SIGHUP, array($this, 'signal_handler'));
             pcntl_signal(SIGINT, array($this, 'signal_handler'));
             pcntl_signal(SIGTERM, array($this, 'signal_handler'));


### PR DESCRIPTION
There are environments where `pcntl_signal` is disabled in `php.ini` but the `pcntl` extension itself is loaded. In these cases it is not enough to check that the `pcntl` extension is loaded. We must also check that `pcntl_signal` exists.

For example, `pcntl_signal` is disabled by default on Debian and Ubuntu: https://www.apt-browse.org/browse/debian/jessie/main/amd64/php5-common/5.6.20+dfsg-0+deb8u1/file/usr/share/php5/php.ini-production