### PR TITLE
Added support for PSR-3 compliant logger.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "ext-libxml": "*",
         "ext-openssl": "*",
         "ext-pcre": "*",
-        "ext-sockets": "*"
+        "ext-sockets": "*",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^3.7.0",

--- a/src/JAXL/core/jaxl_logger.php
+++ b/src/JAXL/core/jaxl_logger.php
@@ -75,14 +75,14 @@ class JAXLLogger
 
     public static function log($msg, $verbosity = self::ERROR)
     {
+        $bt = debug_backtrace();
+        array_shift($bt);
+        $callee = array_shift($bt);
+        $msg = basename($callee['file'], '.php').":".$callee['line']." - ".@date('Y-m-d H:i:s')." - ".$msg;
+
         self::getPsr3Logger()->log(self::$psr3LogLevelMap[$verbosity], $msg);
 
         if ($verbosity <= self::$level) {
-            $bt = debug_backtrace();
-            array_shift($bt);
-            $callee = array_shift($bt);
-            $msg = basename($callee['file'], '.php').":".$callee['line']." - ".@date('Y-m-d H:i:s')." - ".$msg;
-
             $size = strlen($msg);
             if ($size > self::$max_log_size) {
                 $msg = substr($msg, 0, self::$max_log_size) . ' ...';

--- a/src/JAXL/core/jaxl_logger.php
+++ b/src/JAXL/core/jaxl_logger.php
@@ -1,4 +1,8 @@
 <?php
+
+use Psr\Log\LogLevel;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 /**
  * Jaxl (Jabber XMPP Library)
  *
@@ -59,8 +63,20 @@ class JAXLLogger
         self::DEBUG => 37  // white
     );
 
+    private static $psr3Logger;
+
+    private static $psr3LogLevelMap = [
+        self::ERROR => LogLevel::ERROR,
+        self::WARNING => LogLevel::WARNING,
+        self::NOTICE => LogLevel::NOTICE,
+        self::INFO => LogLevel::INFO,
+        self::DEBUG => LogLevel::DEBUG,
+    ];
+
     public static function log($msg, $verbosity = self::ERROR)
     {
+        self::getPsr3Logger()->log(self::$psr3LogLevelMap[$verbosity], $msg);
+
         if ($verbosity <= self::$level) {
             $bt = debug_backtrace();
             array_shift($bt);
@@ -136,5 +152,25 @@ class JAXLLogger
         foreach ($colors as $k => $v) {
             self::$colors[$k] = $v;
         }
+    }
+
+    /**
+     * @param \Psr\Log\LoggerInterface $psr3Logger
+     */
+    public static function setPsr3Logger(LoggerInterface $psr3Logger)
+    {
+        self::$psr3Logger = $psr3Logger;
+    }
+
+    /**
+     * @return \Psr\Log\LoggerInterface
+     */
+    public static function getPsr3Logger()
+    {
+        if (self::$psr3Logger === null) {
+            self::$psr3Logger = new NullLogger();
+        }
+
+        return self::$psr3Logger;
     }
 }

--- a/src/JAXL/jaxl.php
+++ b/src/JAXL/jaxl.php
@@ -1,4 +1,6 @@
 <?php
+
+use Psr\Log\LoggerInterface;
 /**
 * Jaxl (Jabber XMPP Library)
 *
@@ -122,8 +124,9 @@ class JAXL extends XMPPStream
     
     /**
      * @param array $config
+     * @param LoggerInterface $psr3Logger
      */
-    public function __construct(array $config)
+    public function __construct(array $config, LoggerInterface $psr3Logger = null)
     {
         $cfg_defaults = array(
             'auth_type' => 'PLAIN',
@@ -153,6 +156,10 @@ class JAXL extends XMPPStream
         JAXLLogger::$path = $this->cfg['log_path'];
         JAXLLogger::$level = $this->log_level = $this->cfg['log_level'];
         JAXLLogger::$colorize = $this->log_colorize = $this->cfg['log_colorize'];
+
+        if ($psr3Logger !== null) {
+            JAXLLogger::setPsr3Logger($psr3Logger);
+        }
 
         // env
         if ($this->cfg['strict']) {

--- a/tests/JAXLLoggerTest.php
+++ b/tests/JAXLLoggerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Psr\Log\LogLevel;
+
 class JAXLLoggerTest extends PHPUnit_Framework_TestCase
 {
 
@@ -32,5 +34,19 @@ class JAXLLoggerTest extends PHPUnit_Framework_TestCase
         $msg = 'Test message';
         uopz_backup('error_log');
         JAXLLogger::log($msg);
+    }
+
+    /**
+     * @requires PHP 5.4
+     * @requires function uopz_backup
+     */
+    public function testPsr3Logger()
+    {
+        $msg = 'Test message';
+        $logger = $this->getMock('\Psr\Log\LoggerInterface');
+        $logger->expects($this->once())->method('log')->with(LogLevel::ERROR, $msg);
+        JAXLLogger::setPsr3Logger($logger);
+
+        JAXLLogger::log($msg, JAXLLogger::ERROR);
     }
 }


### PR DESCRIPTION
This PR adds ability to use PSR-3 compliant logger alongside JAXL's logging service implementation.

JAXL logging implementation is not modified, and logging levels are properly mapped to the ones defined by PSR-3.

Feel free to suggest better design implementation than the one I presented here.

Thanks!