### PR TITLE
Added write callback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "ext-libxml": "*",
         "ext-openssl": "*",
         "ext-pcre": "*",
-        "ext-sockets": "*"
+        "ext-sockets": "*",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^3.7.0",

--- a/src/JAXL/core/jaxl_logger.php
+++ b/src/JAXL/core/jaxl_logger.php
@@ -1,4 +1,8 @@
 <?php
+
+use Psr\Log\LogLevel;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 /**
  * Jaxl (Jabber XMPP Library)
  *
@@ -59,8 +63,20 @@ class JAXLLogger
         self::DEBUG => 37  // white
     );
 
+    private static $psr3Logger;
+
+    private static $psr3LogLevelMap = [
+        self::ERROR => LogLevel::ERROR,
+        self::WARNING => LogLevel::WARNING,
+        self::NOTICE => LogLevel::NOTICE,
+        self::INFO => LogLevel::INFO,
+        self::DEBUG => LogLevel::DEBUG,
+    ];
+
     public static function log($msg, $verbosity = self::ERROR)
     {
+        self::getPsr3Logger()->log(self::$psr3LogLevelMap[$verbosity], $msg);
+
         if ($verbosity <= self::$level) {
             $bt = debug_backtrace();
             array_shift($bt);
@@ -136,5 +152,25 @@ class JAXLLogger
         foreach ($colors as $k => $v) {
             self::$colors[$k] = $v;
         }
+    }
+
+    /**
+     * @param \Psr\Log\LoggerInterface $psr3Logger
+     */
+    public static function setPsr3Logger(LoggerInterface $psr3Logger)
+    {
+        self::$psr3Logger = $psr3Logger;
+    }
+
+    /**
+     * @return \Psr\Log\LoggerInterface
+     */
+    public static function getPsr3Logger()
+    {
+        if (self::$psr3Logger === null) {
+            self::$psr3Logger = new NullLogger();
+        }
+
+        return self::$psr3Logger;
     }
 }

--- a/src/JAXL/core/jaxl_loop.php
+++ b/src/JAXL/core/jaxl_loop.php
@@ -62,6 +62,9 @@ class JAXLLoop
     private static $secs = 0;
     private static $usecs = 30000;
 
+    private static $next_batch_cb;
+    private static $next_batch_time;
+
     private function __construct()
     {
     }
@@ -118,6 +121,10 @@ class JAXLLoop
             self::$is_running = true;
             self::$clock = new JAXLClock();
 
+            if (self::$next_batch_time && self::$next_batch_cb) {
+                self::$clock->call_fun_periodic(self::$next_batch_time, self::$next_batch_cb);
+            }
+
             while ((self::$active_read_fds + self::$active_write_fds) > 0) {
                 self::select();
             }
@@ -164,5 +171,10 @@ class JAXLLoop
             //JAXLLogger::debug("nothing changed while selecting for read");
             self::$clock->tick((self::$secs * pow(10, 6)) + self::$usecs);
         }
+    }
+
+    public static function set_next_batch_cb($cb, $time = 15000000) {
+        self::$next_batch_cb = $cb;
+        self::$next_batch_time = $time;
     }
 }

--- a/src/JAXL/jaxl.php
+++ b/src/JAXL/jaxl.php
@@ -1,4 +1,6 @@
 <?php
+
+use Psr\Log\LoggerInterface;
 /**
 * Jaxl (Jabber XMPP Library)
 *
@@ -122,8 +124,9 @@ class JAXL extends XMPPStream
     
     /**
      * @param array $config
+     * @param LoggerInterface $psr3Logger
      */
-    public function __construct(array $config)
+    public function __construct(array $config, LoggerInterface $psr3Logger = null)
     {
         $cfg_defaults = array(
             'auth_type' => 'PLAIN',
@@ -153,6 +156,10 @@ class JAXL extends XMPPStream
         JAXLLogger::$path = $this->cfg['log_path'];
         JAXLLogger::$level = $this->log_level = $this->cfg['log_level'];
         JAXLLogger::$colorize = $this->log_colorize = $this->cfg['log_colorize'];
+
+        if ($psr3Logger !== null) {
+            JAXLLogger::setPsr3Logger($psr3Logger);
+        }
 
         // env
         if ($this->cfg['strict']) {

--- a/src/JAXL/jaxl.php
+++ b/src/JAXL/jaxl.php
@@ -427,6 +427,12 @@ class JAXL extends XMPPStream
         $this->start();
     }
 
+    //called back when we want to get the next batch
+    public function process_next_batch() {
+        JAXLLogger::debug("NEXT BATCH CALLED");
+        $this->ev->emit('get_next_batch');
+    }
+
     public function start(array $opts = array())
     {
         // is bosh bot?
@@ -471,6 +477,11 @@ class JAXL extends XMPPStream
             }
             if (isset($opts['--with-unix-sock']) && $opts['--with-unix-sock']) {
                 $this->enable_unix_sock();
+            }
+
+            if ($this->cfg["batched_data"]) {
+                //set the callback for our data checks, time in microseconds
+                JAXLLoop::set_next_batch_cb(array(&$this, 'process_next_batch'), 2000000);
             }
             
             // run main loop

--- a/src/JAXL/jaxl.php
+++ b/src/JAXL/jaxl.php
@@ -434,12 +434,6 @@ class JAXL extends XMPPStream
         $this->start();
     }
 
-    //called back when we want to get the next batch
-    public function process_next_batch() {
-        JAXLLogger::debug("NEXT BATCH CALLED");
-        $this->ev->emit('get_next_batch');
-    }
-
     public function start(array $opts = array())
     {
         // is bosh bot?
@@ -486,10 +480,7 @@ class JAXL extends XMPPStream
                 $this->enable_unix_sock();
             }
 
-            if ($this->cfg["batched_data"]) {
-                //set the callback for our data checks, time in microseconds
-                JAXLLoop::set_next_batch_cb(array(&$this, 'process_next_batch'), 2000000);
-            }
+            JAXLLoop::set_write_callback(array($this, 'write'));
             
             // run main loop
             JAXLLoop::run();
@@ -871,5 +862,10 @@ class JAXL extends XMPPStream
                 //    ', node:'.(isset($child->attrs['node']) ? $child->attrs['node'] : 'NULL').PHP_EOL;
             }
         }
+    }
+
+    public function write()
+    {
+        $this->ev->emit('on_write');
     }
 }

--- a/tests/JAXLLoggerTest.php
+++ b/tests/JAXLLoggerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Psr\Log\LogLevel;
+
 class JAXLLoggerTest extends PHPUnit_Framework_TestCase
 {
 
@@ -32,5 +34,19 @@ class JAXLLoggerTest extends PHPUnit_Framework_TestCase
         $msg = 'Test message';
         uopz_backup('error_log');
         JAXLLogger::log($msg);
+    }
+
+    /**
+     * @requires PHP 5.4
+     * @requires function uopz_backup
+     */
+    public function testPsr3Logger()
+    {
+        $msg = 'Test message';
+        $logger = $this->getMock('\Psr\Log\LoggerInterface');
+        $logger->expects($this->once())->method('log')->with(LogLevel::ERROR, $msg);
+        JAXLLogger::setPsr3Logger($logger);
+
+        JAXLLogger::log($msg, JAXLLogger::ERROR);
     }
 }


### PR DESCRIPTION
When JAXL is started it runs in an infinite loop, until there are no more active read/write file descriptors. Reading is fine because stream remains opened and data can come easily. However, writing is not that easy: you need to call `send()` in order to initiate writing data.

This PR adds ability to register your own write callback. It's being invoked on every loop cycle (the same as read callbacks) and it allows you to send data from your code.

Prior to this PR once connection is established you could only listed for incoming requests, and then respond to them. With this PR now you can write data without the need to wait for incoming message first.