### PR TITLE
Added write callback in order to listen for write requests.

### DIFF
--- a/src/JAXL/core/jaxl_loop.php
+++ b/src/JAXL/core/jaxl_loop.php
@@ -62,12 +62,19 @@ class JAXLLoop
     private static $secs = 0;
     private static $usecs = 30000;
 
+    private static $write_callback;
+
     private function __construct()
     {
     }
 
     private function __clone()
     {
+    }
+
+    public static function set_write_callback($write_callback)
+    {
+        self::$write_callback = $write_callback;
     }
 
     public static function watch($fd, $opts)
@@ -119,6 +126,10 @@ class JAXLLoop
             self::$clock = new JAXLClock();
 
             while ((self::$active_read_fds + self::$active_write_fds) > 0) {
+                if (is_callable(self::$write_callback)) {
+                    call_user_func(self::$write_callback);
+                }
+
                 self::select();
             }
 

--- a/src/JAXL/jaxl.php
+++ b/src/JAXL/jaxl.php
@@ -234,6 +234,8 @@ class JAXL extends XMPPStream
         // lifecycle events callback
         $this->ev = new JAXLEvent($this->cfg['multi_client'] ? array(&$this) : array());
 
+        JAXLLoop::set_write_callback(array($this, 'write'));
+
         // initialize xmpp stream with configured transport
         parent::__construct(
             $transport,
@@ -853,5 +855,10 @@ class JAXL extends XMPPStream
                 //    ', node:'.(isset($child->attrs['node']) ? $child->attrs['node'] : 'NULL').PHP_EOL;
             }
         }
+    }
+
+    public function write()
+    {
+        $this->ev->emit('on_write');
     }
 }


### PR DESCRIPTION
When JAXL is started it runs in an infinite loop, until there are no more active read/write file descriptors. Reading is fine because stream remains opened and data can come easily. However, writing is not that easy: you need to call `send()` in order to initiate writing data.

This PR adds ability to register your own write callback. It's being invoked on every loop cycle (the same as read callbacks) and it allows you to send data from your code.

Prior to this PR once connection is established you could only listed for incoming requests, and then respond to them. With this PR now you can write data without the need to wait for incoming message first.

If you like this idea I could add the docs as well.